### PR TITLE
[WW-3871] Disable bindable for customValidation property

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -50,22 +50,6 @@ export default {
         'update:sidepanel-content',
     ],
     setup(props, { emit }) {
-        /* wwEditor:start */
-        // Migration: Convert bindable validation to non-bindable
-        const componentRawContent = inject('componentRawContent', null);
-        if (componentRawContent?.validation?.__wwtype) {
-            const rawFormula = componentRawContent.validation;
-            emit('update:content:effect', {
-                validation: {
-                    type: rawFormula.__wwtype, // Preserve 'f' or 'js'
-                    code: rawFormula.code,
-                    ...(rawFormula.filter && { filter: rawFormula.filter }),
-                    ...(rawFormula.sort && { sort: rawFormula.sort }),
-                    ...(rawFormula.__wwmap && { __wwmap: rawFormula.__wwmap })
-                }
-            });
-        }
-        /* wwEditor:end */
 
         const isEditing = computed(() => {
             /* wwEditor:start */

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -50,6 +50,23 @@ export default {
         'update:sidepanel-content',
     ],
     setup(props, { emit }) {
+        /* wwEditor:start */
+        // Migration: Convert bindable validation to non-bindable
+        const componentRawContent = inject('componentRawContent', null);
+        if (componentRawContent?.validation?.__wwtype) {
+            const rawFormula = componentRawContent.validation;
+            emit('update:content:effect', {
+                validation: {
+                    type: rawFormula.__wwtype, // Preserve 'f' or 'js'
+                    code: rawFormula.code,
+                    ...(rawFormula.filter && { filter: rawFormula.filter }),
+                    ...(rawFormula.sort && { sort: rawFormula.sort }),
+                    ...(rawFormula.__wwmap && { __wwmap: rawFormula.__wwmap })
+                }
+            });
+        }
+        /* wwEditor:end */
+
         const isEditing = computed(() => {
             /* wwEditor:start */
             return props.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION;

--- a/ww-config.js
+++ b/ww-config.js
@@ -409,7 +409,7 @@ export default {
             section: 'settings',
             type: 'Formula',
             defaultValue: '',
-            bindable: true,
+            bindable: false,
             hidden: (content, sidePanelContent) => {
                 return !sidePanelContent.form?.uid || !content.customValidation;
             },


### PR DESCRIPTION
## Summary
- Disable bindable property for customValidation in form input configuration

## Test plan
- [ ] Verify customValidation property is no longer bindable in the editor
- [ ] Confirm form validation still works correctly